### PR TITLE
Add search.gov credentials

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -100,8 +100,8 @@ primary_navigation:
 # 3. Add your site/affiliate name here.
 searchgov:
   endpoint: https://search.usa.gov # You should not change this.
-  affiliate: federalist-uswds-example # replace this with your search.gov account
-  access_key: xX1gtb2RcnLbIYkHAcB6IaTRr4ZfN-p16ofcyUebeko= # This is placeholder. Not private.
+  affiliate: derisking-guide # search.gov handle
+  access_key: xX1gtb2RcnLbIYkHAcB6IaTRr4ZfN-p16ofcyUebeko= # Not private.
   inline: true #this renders the results on the same domain. Otherwise, it will render the results in the search.gov domain
 
 ##########################################################################################


### PR DESCRIPTION
Adds API key and affiliate handle to config file. Still to do: Ask search.gov to index site.