### PR TITLE
Add Google Analytics and DAP subagency

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,7 +61,7 @@ dap_agency: GSA
 # USPS    - Postal Service
 # SBA     - Small Business Administration
 # SSA     - Social Security Administration
-
+dap_subagency: 18F,TTS
 
 
 # Site Navigation

--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ url: "https://derisking-guide.18f.gov" # the base hostname & protocol for your s
 twitter: 18F
 
 # Configuration for Google Analytics, add your UA code here:
-google_analytics_ua: UA-48605964-1
+google_analytics_ua: UA-48605964-19
 
 
 dap_agency: GSA

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,17 @@
+{% if site.google_analytics_ua %}
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_ua }}"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments); }
+gtag('js', new Date());
+
+// `forceSSL` was used for analytics.js (the older Google Analytics script). It isn't documented for gtag.js, but the term occurs in the gtag.js code; figure it doesn't hurt to leave it in. -@afeld, 5/29/19
+gtag('config', '{{ site.google_analytics_ua }}', { 'anonymize_ip': true, 'forceSSL': true });
+</script>
+{% endif %}
+
+{% if site.dap_agency %}
+<!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
+<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency={{ site.dap_agency }}{% if site.dap_subagency %}&subagency={{ site.dap_subagency }}{% endif %}"></script>
+{% endif %}

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -48,4 +48,8 @@ site, this is the place to do it.
   <!-- CSS
     ================================================== -->
   {% asset index.scss %}
+
+  {% if site.google_analytics_ua or site.dap_agency %}
+      {% include analytics.html %}
+    {% endif %}
 </head>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,6 +1,2 @@
-<!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
-<script id="_fed_an_ua_tag"
-  src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency={{site.dap_agency}}"></script>
-
 {% asset uswds.min.js %}
 {% asset app.js %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,6 @@ The home page uses wide.html layout, since it extends full width of page
   {% include footer.html %}
 
   {% include scripts.html %}
-  {% include analytics.html %}
 </body>
 
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,6 +21,7 @@ The home page uses wide.html layout, since it extends full width of page
   {% include footer.html %}
 
   {% include scripts.html %}
+  {% include analytics.html %}
 </body>
 
 </html>


### PR DESCRIPTION
This PR add google analytics (separate from DAP) to the site:
- Changes the Google Analytics UA to the 18F Microsite code
- Adds a DAP subagency
- Moves the analytics scripts from `body` to `head`

[Preview](https://federalist-fe6e9378-2eb1-4eb8-a686-9f9a574a410d.app.cloud.gov/preview/18f/derisking-gov-tech/ik-add-ga/)

@hbillings Would love another pair of eyes to take a look at this before I merge in. 