### PR TITLE
Remove red flag about user testing

### DIFF
--- a/_pages/federal-fieldguide/4-deciding-what-to-buy.md
+++ b/_pages/federal-fieldguide/4-deciding-what-to-buy.md
@@ -543,8 +543,6 @@ Red flags:
 
 -   They describe the goal of research as being to "test the app with users," "find problems," or ask users what they "like," "want," or "might do" (shows that they draw conclusions based on what users say instead of observing and learning from users what they do).
 
--   They use the term "user testing" instead of "usability testing" (not testing the user, testing the system's functionality).
-
 -   They propose relying on focus groups, instead of structured, one-on-one research interviews or usability testing sessions.
 
 -   They prioritize aesthetics over usability and usefulness, and cannot explain why they made design decisions. 


### PR DESCRIPTION
While this red flag makes for a nice, pithy statement, it misunderstands linguistics. Breathalyzer tests, drug tests, etc. doesn't test the breathalyzer or the drug. Compounds like "_____ testing" name either the quality being tested (security, **usability**), the testing instrument (breathalyzer, **user**), the activity being tested (driving, crash), the target being tested, etc.

"User testing" occurs frequently in textbook, literature, articles, etc. – all of which understand perfectly that it is not the user being tested, but the application. They presumably are also sensitive to the flexible construction of compound nouns, and therefore find no issue with "user testing". This list item seems to just be a particular axe to grind, and is not a basis for a red flag.

If a submission really does misunderstand the purpose of usability testing, it will be evident and can be penalized for it – rather than penalizing a submission for a word choice that is valid.