### PR TITLE
Remove red flag relating to use of articles and capitalization

### DIFF
--- a/_pages/federal-fieldguide/4-deciding-what-to-buy.md
+++ b/_pages/federal-fieldguide/4-deciding-what-to-buy.md
@@ -521,8 +521,6 @@ Red flags:
 
 -   Don't seem to understand program goals. They seriously misunderstand information that was described clearly in the solicitation.
 
--   Misidentifying the name of technologies in such a way that shows a lack of experience communicating about them (e.g. "we'll index records with an Elasticsearch," instead of "with Elasticsearch," or "we recommend using JAVA," instead of "Java").
-
 -   Excessive complexity. 
 
 -   They shirk page-limit rules (tiny fonts, reduced leading, etc.) because they believe their technical approach to be so brilliant that it can't possibly fit within the prescribed limit.


### PR DESCRIPTION
> Misidentifying the name of technologies in such a way that shows a lack of experience communicating about them (e.g. "we'll index records with an Elasticsearch," instead of "with Elasticsearch," or "we recommend using JAVA," instead of "Java").

In my experience procuring software from teams for whom English is a second language, errors with respect to articles, prepositions and capitalization are common. Such errors do not imply a lack of technical proficiency.

In any case, if a team lacks technical proficiency, then it will be clear from other parts of the proposal – a few stray articles, prepositions and letter cases won't be the sole evidence you need to rely on.

To avoid unfairly prejudicing the evaluators against teams for whom English is a second language, I suggest removing this list item.