### PR TITLE
Update ruby version to 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '>= 2.5.7'
+ruby '~>2.7.0'
 
 source "https://rubygems.org"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.7.0p0
 
 BUNDLED WITH
-   1.17.3
+   2.1.2


### PR DESCRIPTION
This PR updates the Gemfile to specify ruby version ~>2.7 given that 2.6 has reached end-of-life and is not longer supported on Federalist. 